### PR TITLE
Remove Facebook from contact options

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,6 @@ title: "Hey, I'm Benji"
 
       <section class="contact-points-section contact-points-signup">
          <nav>
-          <a class="social-icon social-icon-facebook p-url" href="http://www.facebook.com/heybenji" rel="me">Facebook</a>
           <a class="social-icon social-icon-twitter p-url" href="https://twitter.com/heybenji" rel="me">Twitter</a>
           <a class="social-icon social-icon-linkedin p-url" href="https://www.linkedin.com/in/heybenji" rel="me">LinkedIn</a>
         </nav>


### PR DESCRIPTION
Because Facebook is terrible and we don't need terrible things.